### PR TITLE
Added overwrite policy for hspec-discover installation

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,7 +38,7 @@ jobs:
         cabal update
         cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Install test dependencies
-      run: cabal install hspec-discover	
+      run: cabal install hspec-discover	--overwrite-policy=always
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests


### PR DESCRIPTION
This to prevent CI from failing when hspec-discover is already present